### PR TITLE
Changes LET to VAR

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ module.exports = extname;
 
 //get extension of a file
 function extname (str) {
-	let slug = str.split(/\/|\\/).slice(-1)[0];
-	let idx = slug.lastIndexOf('.');
+	var slug = str.split(/\/|\\/).slice(-1)[0];
+	var idx = slug.lastIndexOf('.');
 	if (idx <= 0) return '';
-	let ext = slug.slice(idx);
+	var ext = slug.slice(idx);
 	return ext;
 }


### PR DESCRIPTION
Hi there,

When using this plugin with a non-babel setup, the `let` blocks throw an error.

I don't see why they need to be `let` as the scope is within a function block, so i think we can safely use var instead.

Ash